### PR TITLE
fix srcloc pie exn bug

### DIFF
--- a/pie-err.rkt
+++ b/pie-err.rkt
@@ -1,5 +1,5 @@
 #lang racket/base
-(require racket/string racket/port)
+(require racket/string racket/port racket/match)
 (require "locations.rkt")
 (require "resugar.rkt")
 (require "pretty.rkt")
@@ -9,7 +9,9 @@
 (struct exn:fail:pie exn:fail (where)
   #:property prop:exn:srclocs
   (lambda (e)
-    (list (exn:fail:pie-where e)))
+    (match (exn:fail:pie-where e)
+      [(list src line col pos span)
+       (list (srcloc src line col pos span))]))
   #:transparent)
 
 (define (raise-pie-error where msg)


### PR DESCRIPTION
Fixes small bug regarding Pie's errors and their providing of srcloc structs.

Was fixed by https://github.com/david-christiansen/little-dtp/pull/11 but it looks like the fix didn't make it in the trek to the new repo ;-)