### PR TITLE
better pie error highlighting in DrRacket

### DIFF
--- a/pie-err.rkt
+++ b/pie-err.rkt
@@ -10,7 +10,15 @@
   #:property prop:exn:srclocs
   (lambda (e)
     (match (exn:fail:pie-where e)
-      [(list src line col pos span)
+      [(list raw-src line col pos span)
+       ;; DrRacket highlights more consistently if we
+       ;; return an actual path for the source when
+       ;; the source string corresponds to a valid
+       ;; file on the user's machine.
+       (define src (if (and (string? raw-src)
+                            (file-exists? raw-src))
+                       (string->path raw-src)
+                       raw-src))
        (list (srcloc src line col pos span))]))
   #:transparent)
 


### PR DESCRIPTION
Basically, after the change to use a more primitive representation of source location info within Pie (i.e. a list of primitives rather than a struct) error messages in DrRacket no longer highlighted the corresponding syntax in the definitions window if the user was working in a saved file (highlighting in unsaved editors still worked).

This change just tweaks the `prop:exn:srclocs` property on `exn:fail:pie` structs so they convert the data describing the "source" (i.e. file name or similar) into an actual Racket `path` when possible so DrRacket once again highlights the syntax locations associated with pie exceptions.