### PR TITLE
indent better in DrRacket

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -314,17 +314,19 @@
                                  [(or 'trans 'ind-Vec) 2]
                                  [_ 1]))
                              ;; find if last
-                             (and-let* ([targets-end
-                                         (let loop ([i target-count]
-                                                    [pos (add1 sexp-start)])
-                                           (if (> i 0)
-                                               (loop (sub1 i)
-                                                     (send txt get-forward-sexp pos))
-                                               pos))]
-                                        [first-line-sexp-end (send txt get-forward-sexp pos)])
-                                       (if (>= first-line-sexp-end targets-end)
-                                           (+ 1 indent-basis)
-                                           (+ 4 indent-basis)))]
+                             (let ([targets-end
+                                    (let loop ([i target-count]
+                                               [pos (add1 sexp-start)])
+                                      (if (> i 0)
+                                          (loop (sub1 i)
+                                                (send txt get-forward-sexp pos))
+                                          pos))])
+                               (and targets-end
+                                    (let ([first-line-sexp-end (send txt get-forward-sexp pos)])
+                                      (if (or (not first-line-sexp-end)
+                                              (>= first-line-sexp-end targets-end))
+                                          (+ 1 indent-basis)
+                                          (+ 4 indent-basis)))))]
                             [other
                              #:when (or (eqv? op '->) (eqv? op '→))
                              (and-let* ([sexp-end (send txt get-forward-sexp sexp-start)]


### PR DESCRIPTION
The previous behavior would not indent when you pressed return after typing the targets of elimination-- it waited until another sexp was written and then would ident that sexp correctly after pressing tab. This commit makes indenting happen immediately upon pressing return after giving the target(s) of elimination.