### PR TITLE
Make Pie call-by-need instead of call-by-value

### DIFF
--- a/basics.rkt
+++ b/basics.rkt
@@ -16,6 +16,8 @@
          location->srcloc
          Srcloc)
 
+
+;;; Source locations
 
 (define-type Srcloc (List String Integer Integer Integer Integer))
 
@@ -31,7 +33,8 @@
 ;;; it should not be a trivial value.
 (define-type Loc Precise-Loc)
 
-;%%%%%DPF Portland+2 Shouldn't Pie Keywords include ind-Sigma (?)  
+
+;;; Keywords
 
 (define-type Pie-Keyword
   (U 'U
@@ -47,9 +50,12 @@
      'Either 'left 'right 'ind-Either
      'TODO 'the))
 
+
 ;;; Abstract syntax of high-level programs
 
-
+;; @ associates a source location with a Pie expression or
+;; declaration. This allows the implementation to report give precise,
+;; helpful feedback.
 (struct @ ([loc : Loc]
            [stx : Src-Stx])
   #:transparent
@@ -69,6 +75,11 @@
 (define-type Typed-Binder
   (List Binding-Site Src))
 
+
+;;; Pie expressions consist of a source location attached by @ to an
+;;; S-expression that follows the structure defined in The Little
+;;; Typer. Each sub-expression also has a source location, so they are
+;;; Src rather than Src-Stx.
 (define-type Src-Stx
   (U (List 'the Src Src)
      'U
@@ -120,8 +131,10 @@
      'TODO
      (List* Src Src (Listof Src))))
 
-
-
+;; Core Pie expressions are the result of type checking (elaborating)
+;; an expression written in Pie. They do not have source positions,
+;; because they by definition are not written by a user of the
+;; implementation.
 (define-type Core
   (U (List 'the Core Core)
      'U
@@ -168,8 +181,26 @@
      (List 'TODO Srcloc Core)
      (List Core Core)))
 
+
+;;; Values
+
+;; In order to type check Pie, it is necessary to find the normal
+;; forms of expressions and compare them with each other. The normal
+;; form of an expression is determined by its type - types that have
+;; η-rules (such as Π, Σ, Trivial, and Absurd) impose requirements on
+;; the normal form. For instance, every normal function has λ at the
+;; top, and every normal pair has cons at the top.
+
+;; Finding normal forms has two steps: first, programs are evaluated,
+;; much as they are with the Scheme interpreter at the end of The
+;; Little Schemer. Then, these values are "read back" into the syntax
+;; of their normal forms. This happens in normalize.rkt. This file
+;; defines the values that expressions can have. Structures or symbols
+;; that represent values are written in ALL-CAPS.
+
 ;; Laziness is implemented by allowing values to be a closure that
-;; does not bind a variable.
+;; does not bind a variable. It is described in normalize.rkt (search
+;; for "Call-by-need").
 (struct DELAY-CLOS ([env : Env] [expr : Core]) #:transparent)
 (struct DELAY ([val : (Boxof (U DELAY-CLOS Value))]) #:transparent)
 
@@ -210,6 +241,10 @@
      EITHER LEFT RIGHT
      NEU
      DELAY))
+
+
+;; Neutral expressions are represented by structs that ensure that no
+;; non-neutral expressions can be represented.
 
 (struct N-var ([name : Symbol]) #:transparent)
 (struct N-TODO ([where : Srcloc] [type : Value]) #:transparent)
@@ -278,23 +313,63 @@
 
 (define-predicate Neutral? Neutral)
 
+;; Normal forms consist of syntax that is produced by read-back,
+;; following the type. This structure contains a type value and a
+;; value described by the type, so that read-back can later be applied
+;; to it.
 (struct THE ([type : Value] [value : Value]) #:transparent #:type-name Norm)
 
 (define-predicate Norm? Norm)
 
+
+;;; Error handling
+
+;; Messages to be shown to the user contain a mix of text (represented
+;; as strings) and expressions (represented as Core Pie expressions).
 (define-type Message
   (Listof (U String Core)))
 
+;; The result of an operation that can fail, such as type checking, is
+;; represented using either the stop or the go structures.
 (define-type (Perhaps α)
   (U (go α) stop))
 
+;; A successful result
 (struct (α) go ([result : α]) #:transparent)
+
+;; An error message
 (struct stop ([where : Loc] [message : Message]) #:transparent)
 
+;; go-on is very much like let*. The difference is that if any of the
+;; values bound to variables in it are stop, then the entire
+;; expression becomes that first stop. Otherwise, the variables are
+;; bound to the contents of each go.
+(define-syntax (go-on stx)
+  (syntax-parse stx
+    [(go-on () e) (syntax/loc stx e)]
+    [(go-on ((p0 b0) (p b) ...) e)
+     (syntax/loc stx
+       (match b0
+         [(go p0) (go-on ((p b) ...) e)]
+         [(stop where msg) (stop where msg)]))]))
+
+
+;;; Recognizing variable names
+
+;; This macro causes a name to be defined both for Racket macros and
+;; for use in ordinary Racket programs. In Racket, these are
+;; separated.
+;;
+;; Variable name recognition is needed in Racket macros in order to
+;; parse Pie into the Src type, and it is needed in ordinary programs
+;; in order to implement the type checker.
 (define-syntax-rule (define-here-and-for-syntax what impl)
   (begin (define what impl)
          (begin-for-syntax (define what impl))))
 
+;; The type of var-name? guarantees that the implementation will
+;; always accept symbols that are not Pie keywords, and never accept
+;; those that are.
 (: var-name? (-> Symbol Boolean :
                  #:+ (! Pie-Keyword)
                  #:- Pie-Keyword))
@@ -318,22 +393,40 @@
            (eqv? x 'TODO))))
 
 
-(define-syntax (go-on stx)
-  (syntax-parse stx
-    [(go-on () e) (syntax/loc stx e)]
-    [(go-on ((p0 b0) (p b) ...) e)
-     (syntax/loc stx
-       (match b0
-         [(go p0) (go-on ((p b) ...) e)]
-         [(stop where msg) (stop where msg)]))]))
+
+
+;;; Contexts
+
+;; A context maps free variable names to binders.
+(define-type Ctx
+  (Listof (Pair Symbol Binder)))
 
 
-
+;; There are three kinds of binders: a free binder represents a free
+;; variable, that was bound in some larger context by λ, Π, or Σ. A
+;; def binder represents a name bound by define. A claim binder
+;; doesn't actually bind a name; however, it reserves the name for
+;; later definition with define and records the type that will be
+;; used.
 (define-type Binder (U Def Free Claim))
 (define-type Claim claim)
 (struct claim ([type : Value]) #:transparent)
 (struct def ([type : Value] [value : Value]) #:transparent #:type-name Def)
 (struct free ([type : Value]) #:transparent #:type-name Free)
+
+
+;; To find the type of a variable in a context, find the closest
+;; non-claim binder and extract its type.
+(: var-type (-> Ctx Loc Symbol (Perhaps Value)))
+(define (var-type Γ where x)
+  (match Γ
+    ['() (stop where `("Unknown variable" ,x))]
+    [(cons (cons y (claim tv)) Γ-next)
+     (var-type Γ-next where x)]
+    [(cons (cons y b) Γ-next)
+     (if (eqv? x y)
+         (go (binder-type b))
+         (var-type Γ-next where x))]))
 
 (: binder-type (-> Binder Value))
 (define (binder-type b)
@@ -342,37 +435,7 @@
     [(def tv v) tv]
     [(free tv) tv]))
 
-(define-type Ctx
-  (Listof (Pair Symbol Binder)))
-
-(define-type Serializable-Ctx
-  (Listof (List Symbol (U (List 'free Core)
-                          (List 'def Core Core)
-                          (List 'claim Core)))))
-
-(define-predicate serializable-ctx? Serializable-Ctx)
-
-(define-type Env
-  (Listof (Pair Symbol Value)))
-
-(: ctx->env (-> Ctx Env))
-(define (ctx->env Γ)
-  (match Γ
-    [(cons (cons x (def tv v)) Γ-next)
-     (cons (cons x v)
-           (ctx->env Γ-next))]
-    [(cons (cons x (free tv)) Γ-next)
-     (cons (cons x (NEU tv (N-var x)))
-           (ctx->env Γ-next))]
-    [(cons (cons x (claim tv)) Γ-next)
-     (ctx->env Γ-next)]
-    ['() '()]))
-
-(define-type Closure (U FO-CLOS HO-CLOS))
-(struct FO-CLOS ([env : Env] [var : Symbol] [expr : Core]) #:transparent)
-(struct HO-CLOS ([proc : (-> Value Value)]) #:transparent)
-
-
+;; The starting context is empty.
 (: init-ctx Ctx)
 (define init-ctx '())
 
@@ -386,55 +449,112 @@
 (define (bind-val Γ x tv v)
   (cons (cons x (def tv v)) Γ))
 
+
+;; For informationa bout serializable contexts, see the comments in
+;; normalize.rkt.
+(define-type Serializable-Ctx
+  (Listof (List Symbol (U (List 'free Core)
+                          (List 'def Core Core)
+                          (List 'claim Core)))))
+
+(define-predicate serializable-ctx? Serializable-Ctx)
+
+
+
+
+;;; Run-time environments
+
+;; A run-time environment associates a value with each variable.
+(define-type Env
+  (Listof (Pair Symbol Value)))
+
+;; When type checking Pie, it is sometimes necessary to find the
+;; normal form of an expression that has free variables. These free
+;; variables are described in the type checking context. The value
+;; associated with each free variable should be itself - a neutral
+;; expression. ctx->env converts a context into an environment by
+;; assigning a neutral expression to each variable.
+(: ctx->env (-> Ctx Env))
+(define (ctx->env Γ)
+  (match Γ
+    [(cons (cons x (def tv v)) Γ-next)
+     (cons (cons x v)
+           (ctx->env Γ-next))]
+    [(cons (cons x (free tv)) Γ-next)
+     (cons (cons x (NEU tv (N-var x)))
+           (ctx->env Γ-next))]
+    [(cons (cons x (claim tv)) Γ-next)
+     (ctx->env Γ-next)]
+    ['() '()]))
+
+;; Extend an environment with a value for a new variable.
 (: extend-env (-> Env Symbol Value Env))
 (define (extend-env ρ x v) (cons (cons x v) ρ))
 
-(: unfold-defs? (Parameterof Boolean))
-(define unfold-defs? (make-parameter #t))
-
+;; To find the value of a variable in an environment, look it up in
+;; the usual Lisp way using assv.
 (: var-val (-> Env Symbol Value))
 (define (var-val ρ x)
   (match (assv x ρ)
     [(cons y v) v]
     [#f (error (format "Variable ~a not in\n\tρ: ~a\n" x ρ))]))
 
-(: var-type (-> Ctx Loc Symbol (Perhaps Value)))
-(define (var-type Γ where x)
-  (match Γ
-    ['() (stop where `("Unknown variable" ,x))]
-    [(cons (cons y (claim tv)) Γ-next)
-     (var-type Γ-next where x)]
-    [(cons (cons y b) Γ-next)
-     (if (eqv? x y)
-         (go (binder-type b))
-         (var-type Γ-next where x))]))
 
+
+;;; Closures
+
+;; There are two kinds of closures: first-order closures and
+;; higher-order closures. They are used for different purposes in
+;; Pie. It would be possible to have only one representation, but they
+;; are good for different things, so both are included. See
+;; val-of-closure in normalize.rkt for how to find the value of a
+;; closure, given the value for its free variable.
+(define-type Closure (U FO-CLOS HO-CLOS))
+
+;; First-order closures, which are a pair of an environment an an
+;; expression whose free variables are given values by the
+;; environment, are used for most closures in Pie. They are easier to
+;; debug, because their contents are visible rather than being part of
+;; a compiled Racket function. On the other hand, they are more
+;; difficult to construct out of values, because it would be necessary
+;; to first read the values back into Core Pie syntax.
+(struct FO-CLOS ([env : Env] [var : Symbol] [expr : Core]) #:transparent)
+
+;; Higher-order closures re-used Racket's built-in notion of
+;; closure. They are more convenient when constructing closures from
+;; existing values, which happens both during type checking, where
+;; these values are used for things like the type of a step, and
+;; during evaluation, where they are used as type annotations on THE
+;; and NEU.
+(struct HO-CLOS ([proc : (-> Value Value)]) #:transparent)
+
+
+;;; Finding fresh names
+
+;; Find a fresh name, using none of those described in a context.
+;;
+;; This is the implementation of the Γ ⊢ fresh ↝ x form of
+;; judgment. Unlike the rules in the appendix to The Little Typer,
+;; this implementation also accepts a name suggestion so that the code
+;; produced by elaboration has names that are as similar as possible
+;; to those written by the user.
+(: fresh (-> Ctx Symbol Symbol))
+(define (fresh Γ x)
+  (freshen (names-only Γ) x))
+
+;; Find the names that are described in a context, so they can be
+;; avoided.
 (: names-only (-> Ctx (Listof Symbol)))
 (define (names-only Γ)
   (cond
     [(null? Γ) '()]
     [else (cons (car (car Γ)) (names-only (cdr Γ)))]))
 
-(: fresh (-> Ctx Symbol Symbol))
-(define (fresh Γ x)
-  (freshen (names-only Γ) x))
 
+
 ;; Local Variables:
-;; eval: (put 'pmatch 'racket-indent-function 1)
-;; eval: (put 'vmatch 'racket-indent-function 1)
-;; eval: (put 'pmatch-who 'racket-indent-function 2)
-;; eval: (put 'primitive 'racket-indent-function 1)
-;; eval: (put 'derived 'racket-indent-function 0)
-;; eval: (put 'data-constructor 'racket-indent-function 1)
-;; eval: (put 'type-constructor 'racket-indent-function 1)
-;; eval: (put 'tests-for 'racket-indent-function 1)
-;; eval: (put 'hole 'racket-indent-function 1)
 ;; eval: (put 'Π 'racket-indent-function 1)
-;; eval: (put 'Π* 'racket-indent-function 2)
-;; eval: (put 'PI* 'racket-indent-function 1)
 ;; eval: (put 'Σ 'racket-indent-function 1)
-;; eval: (put (intern "?") 'racket-indent-function 1)
-;; eval: (put 'trace-type-checker 'racket-indent-function 1)
 ;; eval: (put 'go-on 'racket-indent-function 1)
 ;; eval: (setq whitespace-line-column 70)
 ;; End:

--- a/basics.rkt
+++ b/basics.rkt
@@ -170,7 +170,8 @@
 
 ;; Laziness is implemented by allowing values to be a closure that
 ;; does not bind a variable.
-(struct DELAY ([env : Env] [expr : Core]) #:transparent)
+(struct DELAY-CLOS ([env : Env] [expr : Core]) #:transparent)
+(struct DELAY ([val : (Boxof (U DELAY-CLOS Value))]) #:transparent)
 
 (struct QUOTE ([name : Symbol]) #:transparent)
 (struct ADD1 ([smaller : Value]) #:transparent)

--- a/basics.rkt
+++ b/basics.rkt
@@ -168,6 +168,9 @@
      (List 'TODO Srcloc Core)
      (List Core Core)))
 
+;; Laziness is implemented by allowing values to be a closure that
+;; does not bind a variable.
+(struct DELAY ([env : Env] [expr : Core]) #:transparent)
 
 (struct QUOTE ([name : Symbol]) #:transparent)
 (struct ADD1 ([smaller : Value]) #:transparent)
@@ -204,7 +207,8 @@
      EQUAL SAME
      VEC 'VECNIL VEC::
      EITHER LEFT RIGHT
-     NEU))
+     NEU
+     DELAY))
 
 (struct N-var ([name : Symbol]) #:transparent)
 (struct N-TODO ([where : Srcloc] [type : Value]) #:transparent)

--- a/rep.rkt
+++ b/rep.rkt
@@ -27,8 +27,7 @@
   (match (go-on ((`(the ,t-out ,e-out) (synth Γ '() e)))
                 (let ((tv (val-in-ctx Γ t-out))
                       (v (val-in-ctx Γ e-out)))
-                  (go `(the ,(parameterize ([unfold-defs? #f])
-                               (read-back-type Γ tv))
+                  (go `(the ,(read-back-type Γ tv)
                             ,(read-back Γ tv v)))))
     [(go e) (go e)]
     [(stop where msg)

--- a/show-goal.rkt
+++ b/show-goal.rkt
@@ -6,6 +6,9 @@
 
 (provide goal->strings indent-string)
 
+;;; This module implements showing TODO goals to users in the format
+;;; described in the second recess of The Little Typer.
+
 (define (goal->strings loc Γ t)
   (define hole-summary
     (with-output-to-string

--- a/tests.rkt
+++ b/tests.rkt
@@ -756,9 +756,284 @@
                   'NAT
                   (ADD1
                    (DELAY
-                    (list (cons 'four (ADD1 (DELAY '() '(add1 (add1 (add1 zero)))))))
-                    '(add1 (add1 (add1 four)))))))
-               (cons 'four (def 'NAT (ADD1 (DELAY '() '(add1 (add1 (add1 zero)))))))))
+                    (box
+                     (DELAY-CLOS
+                      (list
+                       (cons
+                        'four
+                        (ADD1 (DELAY (box
+                                      (DELAY-CLOS '() '(add1 (add1 (add1 zero)))))))))
+                      '(add1 (add1 (add1 four)))))))))
+               (cons
+                'four
+                (def 'NAT (ADD1 (DELAY (box
+                                        (DELAY-CLOS '() '(add1 (add1 (add1 zero)))))))))))
+
+;; Check call-by-need relative to the previous test
+(check-equal? (for/fold ([st init-ctx])
+                        ([d (map parse-pie-decl
+                                 (list #'(claim four
+                                                Nat)
+                                       #'(define four
+                                           4)
+                                       #'(claim eight
+                                                Nat)
+                                       #'(define eight
+                                           (add1 (add1 (add1 (add1 four)))))
+                                       #'(claim force (-> Nat Nat))
+                                       #'(define force
+                                           (lambda (n)
+                                             (iter-Nat n
+                                                       zero
+                                                       (lambda (k)
+                                                         (add1 k)))))
+                                       #'(claim go (= Nat eight (force eight)))
+                                       #'(define go (same eight))))])
+                (match d
+                  [`(claim ,x ,loc ,t)
+                   (match (add-claim st x loc t)
+                     [(go new-st) new-st]
+                     [(stop where msg)
+                      (error (format "Nope: ~a" msg))])]
+                  [`(definition ,x ,loc ,v)
+                   (match (add-def st x loc v)
+                     [(go new-st) new-st]
+                     [(stop where msg)
+                      (error (format "Nope: ~a" msg))])]))
+              (list
+               (cons
+                'go
+                (def
+                  (EQUAL
+                   (DELAY '#&NAT)
+                   (DELAY
+                    (box
+                     (ADD1
+                      (DELAY
+                       (box
+                        (ADD1
+                         (DELAY
+                          (box
+                           (ADD1
+                            (DELAY
+                             (box
+                              (ADD1
+                               (DELAY
+                                (box
+                                 (ADD1
+                                  (DELAY
+                                   (box
+                                    (ADD1
+                                     (DELAY
+                                      (box
+                                       (ADD1
+                                        (DELAY
+                                         (box (ADD1 (DELAY '#&ZERO)))))))))))))))))))))))))
+                   (DELAY
+                    (box
+                     (ADD1
+                      (DELAY
+                       (box
+                        (ADD1
+                         (DELAY
+                          (box
+                           (ADD1
+                            (DELAY
+                             (box
+                              (ADD1
+                               (DELAY
+                                (box
+                                 (ADD1
+                                  (DELAY
+                                   (box
+                                    (ADD1
+                                     (DELAY
+                                      (box
+                                       (ADD1
+                                        (DELAY
+                                         (box (ADD1 (DELAY '#&ZERO))))))))))))))))))))))))))
+                  (SAME
+                   (DELAY
+                    (box
+                     (DELAY-CLOS
+                      (list
+                       (cons
+                        'force
+                        (LAM
+                         'n
+                         (FO-CLOS
+                          (list
+                           (cons
+                            'eight
+                            (ADD1
+                             (DELAY
+                              (box
+                               (ADD1
+                                (DELAY
+                                 (box
+                                  (ADD1
+                                   (DELAY
+                                    (box
+                                     (ADD1
+                                      (DELAY
+                                       (box
+                                        (ADD1
+                                         (DELAY
+                                          (box
+                                           (ADD1
+                                            (DELAY
+                                             (box
+                                              (ADD1
+                                               (DELAY
+                                                (box
+                                                 (ADD1 (DELAY '#&ZERO))))))))))))))))))))))))
+                           (cons
+                            'four
+                            (ADD1
+                             (DELAY
+                              (box
+                               (ADD1
+                                (DELAY
+                                 (box (ADD1 (DELAY (box (ADD1 (DELAY '#&ZERO)))))))))))))
+                          'n
+                          '(iter-Nat n (the Nat zero) (λ (k) (add1 k))))))
+                       (cons
+                        'eight
+                        (ADD1
+                         (DELAY
+                          (box
+                           (ADD1
+                            (DELAY
+                             (box
+                              (ADD1
+                               (DELAY
+                                (box
+                                 (ADD1
+                                  (DELAY
+                                   (box
+                                    (ADD1
+                                     (DELAY
+                                      (box
+                                       (ADD1
+                                        (DELAY
+                                         (box
+                                          (ADD1
+                                           (DELAY
+                                            (box (ADD1 (DELAY '#&ZERO))))))))))))))))))))))))
+                       (cons
+                        'four
+                        (ADD1
+                         (DELAY
+                          (box
+                           (ADD1
+                            (DELAY (box (ADD1 (DELAY (box (ADD1 (DELAY '#&ZERO)))))))))))))
+                      'eight))))))
+               (cons
+                'force
+                (def
+                  (PI
+                   'x
+                   (DELAY '#&NAT)
+                   (FO-CLOS
+                    (list
+                     (cons
+                      'eight
+                      (ADD1
+                       (DELAY
+                        (box
+                         (ADD1
+                          (DELAY
+                           (box
+                            (ADD1
+                             (DELAY
+                              (box
+                               (ADD1
+                                (DELAY
+                                 (box
+                                  (ADD1
+                                   (DELAY
+                                    (box
+                                     (ADD1
+                                      (DELAY
+                                       (box
+                                        (ADD1
+                                         (DELAY
+                                          (box (ADD1 (DELAY '#&ZERO))))))))))))))))))))))))
+                     (cons
+                      'four
+                      (ADD1
+                       (DELAY
+                        (box
+                         (ADD1 (DELAY (box (ADD1 (DELAY (box (ADD1 (DELAY '#&ZERO)))))))))))))
+                    'x
+                    'Nat))
+                  (LAM
+                   'n
+                   (FO-CLOS
+                    (list
+                     (cons
+                      'eight
+                      (ADD1
+                       (DELAY
+                        (box
+                         (ADD1
+                          (DELAY
+                           (box
+                            (ADD1
+                             (DELAY
+                              (box
+                               (ADD1
+                                (DELAY
+                                 (box
+                                  (ADD1
+                                   (DELAY
+                                    (box
+                                     (ADD1
+                                      (DELAY
+                                       (box
+                                        (ADD1
+                                         (DELAY
+                                          (box (ADD1 (DELAY '#&ZERO))))))))))))))))))))))))
+                     (cons
+                      'four
+                      (ADD1
+                       (DELAY
+                        (box
+                         (ADD1 (DELAY (box (ADD1 (DELAY (box (ADD1 (DELAY '#&ZERO)))))))))))))
+                    'n
+                    '(iter-Nat n (the Nat zero) (λ (k) (add1 k)))))))
+               (cons
+                'eight
+                (def
+                  'NAT
+                  (ADD1
+                   (DELAY
+                    (box
+                     (ADD1
+                      (DELAY
+                       (box
+                        (ADD1
+                         (DELAY
+                          (box
+                           (ADD1
+                            (DELAY
+                             (box
+                              (ADD1
+                               (DELAY
+                                (box
+                                 (ADD1
+                                  (DELAY
+                                   (box
+                                    (ADD1
+                                     (DELAY (box (ADD1 (DELAY '#&ZERO)))))))))))))))))))))))))
+               (cons
+                'four
+                (def
+                  'NAT
+                  (ADD1
+                   (DELAY
+                    (box
+                     (ADD1 (DELAY (box (ADD1 (DELAY (box (ADD1 (DELAY '#&ZERO)))))))))))))))
 
 
 (check-equal?

--- a/tests.rkt
+++ b/tests.rkt
@@ -1,10 +1,12 @@
-#lang typed/racket/base
+#lang typed/racket/no-check
 
 (require racket/match)
-(require (except-in typed/rackunit check))
+;(require (except-in typed/rackunit check))
+(require (except-in rackunit check))
 (require "basics.rkt")
 (require "typechecker.rkt")
-
+(require "parser.rkt")
+#;
 (require/typed "parser.rkt"
   [parse-pie (-> Syntax Src)]
   [parse-pie-decl (-> Syntax (U (List (U 'definition 'claim) Symbol Precise-Loc Src)
@@ -748,14 +750,15 @@
                      [(stop where msg)
                       (error (format "Nope: ~a" msg))])]))
               (list
-               (cons 'eight
-                     (def
-                       'NAT
-                       (ADD1 (ADD1 (ADD1 (ADD1 (ADD1 (ADD1 (ADD1 (ADD1 'ZERO))))))))))
-               (cons 'four
-                     (def
-                       'NAT
-                       (ADD1 (ADD1 (ADD1 (ADD1 'ZERO))))))))
+               (cons
+                'eight
+                (def
+                  'NAT
+                  (ADD1
+                   (DELAY
+                    (list (cons 'four (ADD1 (DELAY '() '(add1 (add1 (add1 zero)))))))
+                    '(add1 (add1 (add1 four)))))))
+               (cons 'four (def 'NAT (ADD1 (DELAY '() '(add1 (add1 (add1 zero)))))))))
 
 
 (check-equal?

--- a/typechecker.rkt
+++ b/typechecker.rkt
@@ -466,8 +466,8 @@
      [`(head ,es)
       (go-on ((`(the ,es-type-out ,es-out)
                (synth Γ r es)))
-        (match (val-in-ctx Γ es-type-out)
-          [(VEC Ev (ADD1 len-1))
+        (match (now (val-in-ctx Γ es-type-out))
+          [(VEC Ev (!! (ADD1 len-1)))
            (go `(the ,(read-back-type Γ Ev)
                      (head ,es-out)))]
           [(VEC Ev non-add1)
@@ -482,8 +482,8 @@
      [`(tail ,es)
       (go-on ((`(the ,es-type-out ,es-out)
                (synth Γ r es)))
-        (match (val-in-ctx Γ es-type-out)
-          [(VEC Ev (ADD1 len-1))
+        (match (now (val-in-ctx Γ es-type-out))
+          [(VEC Ev (!! (ADD1 len-1)))
            (go `(the (Vec ,(read-back-type Γ Ev)
                           ,(read-back Γ 'NAT len-1))
                      (tail ,es-out)))]
@@ -619,7 +619,7 @@
   (define out
    (match (src-stx e)
      [`(λ (,(binder x-loc x)) ,b)
-      (match tv
+      (match (now tv)
         [(PI y A c)
          (let ((x^ (fresh Γ x)))
           (go-on ((b-out (check (bind-free Γ x^ A)
@@ -641,7 +641,7 @@
                        `(λ (,y . ,xs) ,b))))
              tv)]
      [`(cons ,a ,d)
-      (match tv
+      (match (now tv)
         [(SIGMA x A c)
          (go-on ((a-out (check Γ r a A))
                  (d-out (check Γ
@@ -654,7 +654,7 @@
                `("cons requires a Pair or Σ type, but was used as a"
                  ,(read-back-type Γ non-Sigma)))])]
      ['nil
-      (match tv
+      (match (now tv)
         [(LIST E)
          (go 'nil)]
         [non-List
@@ -662,7 +662,7 @@
                `("nil requires a List type, but was used as a"
                  ,(read-back-type Γ non-List)))])]
      [`(same ,c)
-      (match tv
+      (match (now tv)
         [(EQUAL Av fromv tov)
          (go-on ((c-out (check Γ r c Av))
                  (v (go (val-in-ctx Γ c-out)))
@@ -674,8 +674,8 @@
                `("same requires an = type, but was used as a"
                  ,(read-back-type Γ non-=)))])]
      ['vecnil
-      (match tv
-        [(VEC Ev 'ZERO)
+      (match (now tv)
+        [(VEC Ev (!! 'ZERO))
          (go 'vecnil)]
         [(VEC Ev non-zero)
          (stop (src-loc e)
@@ -689,8 +689,8 @@
                  ,(read-back-type Γ non-Vec)
                  "context."))])]
      [`(vec:: ,h ,t)
-      (match tv
-        [(VEC Ev (ADD1 len-1))
+      (match (now tv)
+        [(VEC Ev (!! (ADD1 len-1)))
          (go-on ((h-out (check Γ r h Ev))
                  (t-out (check Γ r t (VEC Ev len-1))))
            (go `(vec:: ,h-out ,t-out)))]
@@ -704,7 +704,7 @@
                  ,(read-back-type Γ non-Vec)
                  "context."))])]
      [`(left ,l)
-      (match tv
+      (match (now tv)
         [(EITHER Lv Rv)
          (go-on ((l-out (check Γ r l Lv)))
            (go `(left ,l-out)))]
@@ -714,7 +714,7 @@
                  ,(read-back-type Γ non-Either)
                  "was expected."))])]
      [`(right ,rght)
-      (match tv
+      (match (now tv)
         [(EITHER Lv Rv)
          (go-on ((r-out (check Γ r rght Rv)))
            (go `(right ,r-out)))]

--- a/typechecker.rkt
+++ b/typechecker.rkt
@@ -14,6 +14,37 @@
   [location->srcloc (-> Loc Srcloc)]
   [not-for-info (-> Loc Precise-Loc)])
 
+
+;;; Reporting information
+
+;; The info hook is a procedure to be called by the type checker to
+;; report information about the type of an expression.  The info hook
+;; is called with the position in the source file that it is providing
+;; information about, and the information.
+;;
+;; The information is one of the following:
+;;
+;;  - 'definition, which means that the source position represents a
+;;    defined name. This is used in the interactive slide package to
+;;    enable having the same fonts for defined names as are used in
+;;    The Little Typer.
+;;
+;; - `(binding-site ,TYPE) registers that the position binds a
+;;   variable whose type is TYPE. This is used for tooltips in
+;;   DrRacket as well as in the slides.
+;;
+;; - `(is-type ,TYPE) registers that the position represents the type
+;;   TYPE.
+;;
+;; - `(has-type ,TYPE) registers that the position represents an
+;;   expression with the type TYPE, discovered either through checking
+;;   or synthesis. This is used for tooltips in DrRacket and for
+;;   display in slides.
+;;
+;; - `(TODO ,Γ ,TYPE) registers that the position is a TODO that is
+;;   expected to have the type TYPE in context Γ. This is used for
+;;   tooltips in DrRacket, for the todo-list plugin in DrRacket, and
+;;   for display in slides.
 (: pie-info-hook (Parameterof (-> Loc
                                   (U 'definition
                                      (List 'binding-site Core)
@@ -35,6 +66,13 @@
   (when (location-for-info? where)
     ((pie-info-hook) where what)))
 
+
+;;; Renamings
+
+;; The Pie elaborator ensures that each entry in Γ has a distinct
+;; name, to make it easier for users to discover mistakes induced by
+;; shadowing. To do this, shadowed bindings are renamed, and the
+;; renamings are tracked during elaboration.
 (define-type Renaming (Listof (Pair Symbol Symbol)))
 
 (: rename (-> Renaming Symbol Symbol))
@@ -46,6 +84,9 @@
 (: extend-renaming (-> Renaming Symbol Symbol Renaming))
 (define (extend-renaming r from to)
   (cons (cons from to) r))
+
+
+;;; Check the form of judgment Γ ⊢ e type ↝ c
 
 (: is-type (-> Ctx Renaming Src (Perhaps Core)))
 (define (is-type Γ r in)
@@ -152,6 +193,9 @@
   (go-on ((t the-type))
     (begin (send-pie-info (src-loc in) `(is-type ,t))
            (go t))))
+
+
+;;; Check the form of judgment Γ ⊢ e synth ↝ (the c c)
 
 (: synth (-> Ctx Renaming Src (Perhaps (List 'the Core Core))))
 (define (synth Γ r e)
@@ -613,6 +657,9 @@
     (begin (send-pie-info (src-loc e) `(has-type ,ty))
            the-expr)))
 
+
+;;; Check the form of judgment Γ ⊢ e ∈ e ↝ c
+
 (: check (-> Ctx Renaming Src Value (Perhaps Core)))
 (define (check Γ r e tv)
   (: out (Perhaps Core))
@@ -734,6 +781,9 @@
     (begin (send-pie-info (src-loc e) `(has-type ,(read-back-type Γ tv)))
            out)))
 
+
+;;; Check the form of judgment Γ ⊢ c ≡ c type
+
 (: same-type (-> Ctx Loc Value Value (Perhaps Void)))
 (define (same-type Γ where given expected)
   (let ([given-e (read-back-type Γ given)]
@@ -743,6 +793,9 @@
         (stop where
               `("Expected" ,(read-back-type Γ expected)
                            "but given" ,(read-back-type Γ given))))))
+
+
+;;; Check the form of judgment Γ ⊢ c ≡ c : c
 
 (: convert (-> Ctx Loc Value Value Value (Perhaps Void)))
 (define (convert Γ where tv av bv)
@@ -758,8 +811,8 @@
                 "are not the same"
                 ,(read-back-type Γ tv))))))
 
-;; --------------
-;; Claims + defs
+
+;;; Claims + defs
 
 (: not-used (-> Ctx Loc Symbol (Perhaps #t)))
 (define (not-used Γ where x)
@@ -835,22 +888,10 @@
   (check-false (atom-ok? 'at0m))
   (check-false (atom-ok? '🛶)))
 
+
 ;; Local Variables:
-;; eval: (put 'pmatch 'racket-indent-function 1)
-;; eval: (put 'vmatch 'racket-indent-function 1)
-;; eval: (put 'pmatch-who 'racket-indent-function 2)
-;; eval: (put 'primitive 'racket-indent-function 1)
-;; eval: (put 'derived 'racket-indent-function 0)
-;; eval: (put 'data-constructor 'racket-indent-function 1)
-;; eval: (put 'type-constructor 'racket-indent-function 1)
-;; eval: (put 'tests-for 'racket-indent-function 1)
-;; eval: (put 'hole 'racket-indent-function 1)
 ;; eval: (put 'Π 'racket-indent-function 1)
-;; eval: (put 'Π* 'racket-indent-function 2)
-;; eval: (put 'PI* 'racket-indent-function 1)
 ;; eval: (put 'Σ 'racket-indent-function 1)
-;; eval: (put (intern "?") 'racket-indent-function 1)
-;; eval: (put 'trace-type-checker 'racket-indent-function 1)
 ;; eval: (put 'go-on 'racket-indent-function 1)
 ;; eval: (setq whitespace-line-column 70)
 ;; End:


### PR DESCRIPTION
This fixes the greatest discrepancy between the evaluation strategy suggested in _The Little Typer_ and the one implemented. Feedback on the clarity of the implementation would be wonderful.