### PR TITLE
Adjust error message tests for new Racket format.

### DIFF
--- a/test-todo-output.rkt
+++ b/test-todo-output.rkt
@@ -5,4 +5,4 @@
 (check-equal?
  (with-output-to-string
    (lambda () (dynamic-require "todo-test.pie" #f)))
- "<pkgs>/pie/todo-test.pie:10.15: TODO:\n           n : Nat\n         n-1 : Nat\n peas-of-n-1 : (Vec Atom n-1)\n------------------------------\n Atom\n\n\n<pkgs>/pie/todo-test.pie:10.20: TODO:\n           n : Nat\n         n-1 : Nat\n peas-of-n-1 : (Vec Atom n-1)\n------------------------------\n (Vec Atom n-1)\n\n\n<pkgs>/pie/todo-test.pie:13.17: TODO: Nat\n\n<pkgs>/pie/todo-test.pie:15.19: TODO: \n (Π ((n Nat))\n  (Vec Atom n))\n\n\n")
+ "<pkgs>/pie/todo-test.pie:10:15: TODO:\n           n : Nat\n         n-1 : Nat\n peas-of-n-1 : (Vec Atom n-1)\n------------------------------\n Atom\n\n\n<pkgs>/pie/todo-test.pie:10:20: TODO:\n           n : Nat\n         n-1 : Nat\n peas-of-n-1 : (Vec Atom n-1)\n------------------------------\n (Vec Atom n-1)\n\n\n<pkgs>/pie/todo-test.pie:13:17: TODO: Nat\n\n<pkgs>/pie/todo-test.pie:15:19: TODO: \n (Π ((n Nat))\n  (Vec Atom n))\n\n\n")


### PR DESCRIPTION
Racket changed from <line>.<col> to <line>:<col> in
racket/racket@808ea5f303 in response to racket/racket#3492.

This could be changed to support passing with the old format,
but that seems like a lot of work for not much gain.

Related to racket/racket#3896.